### PR TITLE
Fix build error due to missing header

### DIFF
--- a/src/core/objects.hpp
+++ b/src/core/objects.hpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "materials.hpp"


### PR DESCRIPTION
Encountered a build error on GCC 11 on Manjaro Linux. The <string> header was missing, which is fixed by this commit.